### PR TITLE
Clean-up and made bitfinex module independent of decouple

### DIFF
--- a/bitfinex/__init__.py
+++ b/bitfinex/__init__.py
@@ -1,1 +1,1 @@
-from bitfinex.client import Client
+from bitfinex.client import Client, TradeClient

--- a/bitfinex/client.py
+++ b/bitfinex/client.py
@@ -6,14 +6,9 @@ import hmac
 import hashlib
 import time
 
-from decouple import config
-
 PROTOCOL = "https"
 HOST = "api.bitfinex.com"
 VERSION = "v1"
-
-API_KEY = config('API_KEY')
-API_SECRET = config('API_SECRET')
 
 PATH_SYMBOLS = "symbols"
 PATH_TICKER = "ticker/%s"
@@ -32,8 +27,10 @@ class TradeClient:
     Authenticated client for trading through Bitfinex API
     """
 
-    def __init__(self):
+    def __init__(self, key, secret):
         self.URL = "{0:s}://{1:s}/{2:s}".format(PROTOCOL, HOST, VERSION)
+        self.KEY = key
+        self.SECRET = secret
         pass
 
     @property
@@ -48,10 +45,10 @@ class TradeClient:
         j = json.dumps(payload)
         data = base64.standard_b64encode(j.encode('utf8'))
 
-        h = hmac.new(API_SECRET.encode('utf8'), data, hashlib.sha384)
+        h = hmac.new(self.SECRET.encode('utf8'), data, hashlib.sha384)
         signature = h.hexdigest()
         return {
-            "X-BFX-APIKEY": API_KEY,
+            "X-BFX-APIKEY": self.KEY,
             "X-BFX-SIGNATURE": signature,
             "X-BFX-PAYLOAD": data
         }

--- a/bitfinex/client.py
+++ b/bitfinex/client.py
@@ -50,7 +50,6 @@ class TradeClient:
 
         h = hmac.new(API_SECRET.encode('utf8'), data, hashlib.sha384)
         signature = h.hexdigest()
-        print(API_KEY, signature)
         return {
             "X-BFX-APIKEY": API_KEY,
             "X-BFX-SIGNATURE": signature,

--- a/test/bitfinex_test.py
+++ b/test/bitfinex_test.py
@@ -3,7 +3,12 @@ import mock
 import requests
 import httpretty
 
+from decouple import config
+
 from bitfinex.client import Client, TradeClient
+
+API_KEY = config('API_KEY')
+API_SECRET = config('API_SECRET')
 
 class BitfinexTest(unittest.TestCase):
 
@@ -198,7 +203,7 @@ class BitfinexTest(unittest.TestCase):
 
 class TestTradeClient(unittest.TestCase):
     def setUp(self):
-        self.tc = TradeClient()
+        self.tc = TradeClient(API_KEY, API_SECRET)
 
     def test_instantiate_tradeclient(self):
         self.assertIsInstance(self.tc, TradeClient)


### PR DESCRIPTION
I like to use my own way of storing key/secret pair. Pass them to TradeClient when creating an object.
bitfinex_test.py changes are not tested.

Also did small clean-ups.
