### PR TITLE
fix spelling avg_excution_price

### DIFF
--- a/bitfinex/client.py
+++ b/bitfinex/client.py
@@ -105,7 +105,7 @@ class TradeClient:
         json_resp = r.json()
 
         try:
-            json_resp['avg_excution_price']
+            json_resp['avg_execution_price']
         except:
             return json_resp['message']
 
@@ -144,7 +144,7 @@ class TradeClient:
         json_resp = r.json()
 
         try:
-            json_resp['avg_excution_price']
+            json_resp['avg_execution_price']
         except:
             return json_resp['message']
 


### PR DESCRIPTION
Found this when writing my own auth-tests.

### Fixes
- Minor spelling potentially causing crash.

### Tests
- Don't believe it makes sense to test this since you'd need to make an actual order.
