### PR TITLE
Change /ticker to /pubticker endpoint (and add volume). Do not convert response values to float.

### DIFF
--- a/bitfinex/client.py
+++ b/bitfinex/client.py
@@ -21,6 +21,9 @@ PATH_ORDERBOOK = "book/%s"
 TIMEOUT = 5.0
 
 
+class BitfinexException(Exception):
+    pass
+
 
 class TradeClient:
     """
@@ -84,7 +87,7 @@ class TradeClient:
         try:
             json_resp['order_id']
         except:
-            return json_resp['message']
+            raise BitfinexException(json_resp['message'])
 
         return json_resp
 
@@ -107,7 +110,7 @@ class TradeClient:
         try:
             json_resp['avg_execution_price']
         except:
-            return json_resp['message']
+            raise BitfinexException(json_resp['message'])
 
         return json_resp
 
@@ -146,7 +149,7 @@ class TradeClient:
         try:
             json_resp['avg_execution_price']
         except:
-            return json_resp['message']
+            raise BitfinexException(json_resp['message'])
 
         return json_resp
 

--- a/bitfinex/client.py
+++ b/bitfinex/client.py
@@ -11,7 +11,7 @@ HOST = "api.bitfinex.com"
 VERSION = "v1"
 
 PATH_SYMBOLS = "symbols"
-PATH_TICKER = "ticker/%s"
+PATH_TICKER = "pubticker/%s"
 PATH_TODAY = "today/%s"
 PATH_STATS = "stats/%s"
 PATH_LENDBOOK = "lendbook/%s"
@@ -384,12 +384,13 @@ class Client:
         """
         GET /ticker/:symbol
 
-        curl https://api.bitfinex.com/v1/ticker/btcusd
+        curl https://api.bitfinex.com/v1/pubticker/btcusd
         {
             'ask': '562.9999',
             'timestamp': '1395552290.70933607',
             'bid': '562.25',
             'last_price': u'562.25',
+            'volume': '7842.11542563',
             'mid': u'562.62495'}
         """
         data = self._get(self.url_for(PATH_TICKER, (symbol)))

--- a/bitfinex/client.py
+++ b/bitfinex/client.py
@@ -393,10 +393,7 @@ class Client:
             'volume': '7842.11542563',
             'mid': u'562.62495'}
         """
-        data = self._get(self.url_for(PATH_TICKER, (symbol)))
-
-        # convert all values to floats
-        return self._convert_to_floats(data)
+        return self._get(self.url_for(PATH_TICKER, (symbol)))
 
 
     def today(self, symbol):
@@ -407,10 +404,7 @@ class Client:
         {"low":"550.09","high":"572.2398","volume":"7305.33119836"}
         """
 
-        data = self._get(self.url_for(PATH_TODAY, (symbol)))
-
-        # convert all values to floats
-        return self._convert_to_floats(data)
+        return self._get(self.url_for(PATH_TODAY, (symbol)))
 
 
     def stats(self, symbol):
@@ -430,7 +424,7 @@ class Client:
                 if key == 'period':
                     new_value = int(value)
                 elif key == 'volume':
-                    new_value = float(value)
+                    new_value = value
 
                 period[key] = new_value
 
@@ -456,7 +450,7 @@ class Client:
 
                 for key, value in lend.items():
                     if key in ['rate', 'amount', 'timestamp']:
-                        new_value = float(value)
+                        new_value = value
                     elif key == 'period':
                         new_value = int(value)
                     elif key == 'frr':
@@ -490,17 +484,7 @@ class Client:
         for type_ in data.keys():
             for list_ in data[type_]:
                 for key, value in list_.items():
-                    list_[key] = float(value)
-
-        return data
-
-
-    def _convert_to_floats(self, data):
-        """
-        Convert all values in a dict to floats
-        """
-        for key, value in data.items():
-            data[key] = float(value)
+                    list_[key] = value
 
         return data
 

--- a/test/bitfinex_test.py
+++ b/test/bitfinex_test.py
@@ -76,7 +76,7 @@ class BitfinexTest(unittest.TestCase):
     @httpretty.activate
     def test_should_have_ticker(self):
         # mock out the request
-        mock_body = '{"mid":"562.56495","bid":"562.15","ask":"562.9799","last_price":"562.25","timestamp":"1395552658.339936691"}'
+        mock_body = '{"mid":"562.56495","bid":"562.15","ask":"562.9799","last_price":"562.25","volume":"7842.11542563","timestamp":"1395552658.339936691"}'
         url = self.client.url_for('ticker/%s', path_arg='btcusd')
         httpretty.register_uri(httpretty.GET, url, body=mock_body, status=200)
 
@@ -85,6 +85,7 @@ class BitfinexTest(unittest.TestCase):
             "bid": 562.15,
             "ask": 562.9799,
             "last_price": 562.25,
+            "volume": 7842.11542563,
             "timestamp": 1395552658.339936691
         }
 

--- a/test/bitfinex_test.py
+++ b/test/bitfinex_test.py
@@ -81,12 +81,12 @@ class BitfinexTest(unittest.TestCase):
         httpretty.register_uri(httpretty.GET, url, body=mock_body, status=200)
 
         expected = {
-            "mid": 562.56495,
-            "bid": 562.15,
-            "ask": 562.9799,
-            "last_price": 562.25,
-            "volume": 7842.11542563,
-            "timestamp": 1395552658.339936691
+            "mid": "562.56495",
+            "bid": "562.15",
+            "ask": "562.9799",
+            "last_price": "562.25",
+            "volume": "7842.11542563",
+            "timestamp": "1395552658.339936691"
         }
 
         self.assertEqual(expected, self.client.ticker('btcusd'))
@@ -100,9 +100,9 @@ class BitfinexTest(unittest.TestCase):
         httpretty.register_uri(httpretty.GET, url, body=mock_body, status=200)
 
         expected = {
-            "low": 550.09,
-            "high": 572.2398,
-            "volume": 7305.33119836
+            "low": "550.09",
+            "high": "572.2398",
+            "volume": "7305.33119836"
         }
 
         self.assertEqual(expected, self.client.today('btcusd'))
@@ -116,9 +116,9 @@ class BitfinexTest(unittest.TestCase):
         httpretty.register_uri(httpretty.GET, url, body=mock_body, status=200)
 
         expected = [
-            {"period": 1, "volume": 7410.27250155},
-            {"period": 7, "volume": 52251.37118006},
-            {"period": 30,"volume": 464505.07753251}
+            {"period": 1,  "volume": "7410.27250155"},
+            {"period": 7,  "volume": "52251.37118006"},
+            {"period": 30, "volume": "464505.07753251"}
         ]
 
         self.assertEqual(expected, self.client.stats('btcusd'))
@@ -133,12 +133,12 @@ class BitfinexTest(unittest.TestCase):
 
         expected = {
             "bids": [
-                {"rate": 5.475, "amount": 15.03894663, "period": 30, "timestamp": 1395112149.0, "frr": False},
-                {"rate": 2.409, "amount": 14.5121868, "period": 7, "timestamp": 1395497599.0, "frr": False}
+                {"rate": "5.475", "amount": "15.03894663", "period": 30, "timestamp": "1395112149.0", "frr": False},
+                {"rate": "2.409", "amount": "14.5121868", "period": 7, "timestamp": "1395497599.0", "frr": False}
             ],
             "asks": [
-                {"rate": 6.351, "amount": 15.5180735, "period": 5, "timestamp": 1395549996.0, "frr": False},
-                {"rate": 6.3588, "amount": 626.94808249, "period": 30, "timestamp": 1395400654.0, "frr": True}
+                {"rate": "6.351", "amount": "15.5180735", "period": 5, "timestamp": "1395549996.0", "frr": False},
+                {"rate": "6.3588", "amount": "626.94808249", "period": 30, "timestamp": "1395400654.0", "frr": True}
             ]
         }
 
@@ -155,8 +155,8 @@ class BitfinexTest(unittest.TestCase):
 
         expected = {
             "bids": [
-                {"rate": 5.475, "amount": 15.03894663, "period": 30, "timestamp": 1395112149.0, "frr": False},
-                {"rate": 2.409, "amount": 14.5121868, "period": 7, "timestamp": 1395497599.0, "frr": False}
+                {"rate": "5.475", "amount": "15.03894663", "period": 30, "timestamp": "1395112149.0", "frr": False},
+                {"rate": "2.409", "amount": "14.5121868", "period": 7, "timestamp": "1395497599.0", "frr": False}
             ],
             "asks": [
             ]
@@ -174,10 +174,10 @@ class BitfinexTest(unittest.TestCase):
 
         expected = {
             "bids": [
-                {"price": 562.2601, "amount": 0.985, "timestamp": 1395567556.0}
+                {"price": "562.2601", "amount": "0.985", "timestamp": "1395567556.0"}
             ],
             "asks": [
-                {"price": 563.001, "amount": 0.3, "timestamp": 1395532200.0}
+                {"price": "563.001", "amount": "0.3", "timestamp": "1395532200.0"}
             ]
         }
 
@@ -194,7 +194,7 @@ class BitfinexTest(unittest.TestCase):
 
         expected = {
             "bids": [
-                {"price": 562.2601, "amount": 0.985, "timestamp": 1395567556.0}
+                {"price": "562.2601", "amount": "0.985", "timestamp": "1395567556.0"}
             ],
             "asks": []
         }


### PR DESCRIPTION
There's no /ticker endpoint in the docs. 

https://docs.bitfinex.com/v1/reference#rest-public-ticker

About floats -- please see the issue here: https://github.com/scottjbarr/bitfinex/issues/18