### PR TITLE
Raise an exception instead of returning string error message

### DIFF
--- a/bitfinex/client.py
+++ b/bitfinex/client.py
@@ -21,6 +21,9 @@ PATH_ORDERBOOK = "book/%s"
 TIMEOUT = 5.0
 
 
+class BitfinexException(Exception):
+    pass
+
 
 class TradeClient:
     """
@@ -84,7 +87,7 @@ class TradeClient:
         try:
             json_resp['order_id']
         except:
-            return json_resp['message']
+            raise BitfinexException(json_resp['message'])
 
         return json_resp
 
@@ -107,7 +110,7 @@ class TradeClient:
         try:
             json_resp['avg_execution_price']
         except:
-            return json_resp['message']
+            raise BitfinexException(json_resp['message'])
 
         return json_resp
 
@@ -146,7 +149,7 @@ class TradeClient:
         try:
             json_resp['avg_execution_price']
         except:
-            return json_resp['message']
+            raise BitfinexException(json_resp['message'])
 
         return json_resp
 


### PR DESCRIPTION
Getting string `'Invalid order: minimum size for BTC/USD is 0.005'` is not really helpful -- it's better to raise an exception.